### PR TITLE
I've refactored the code to remove all ground plane objects.

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,7 @@
             directionalLight.shadow.bias = -0.0005;
             scene.add(directionalLight);
             // const shadowHelper = new THREE.CameraHelper(directionalLight.shadow.camera);
+            // const shadowHelper = new THREE.CameraHelper(directionalLight.shadow.camera);
             // scene.add(shadowHelper);
             
             // Ground plane - REMOVED OLD PLANE
@@ -190,26 +191,7 @@
             // plane.receiveShadow = true;
             // scene.add(plane);
 
-            // --- Blocky Road Surface ---
-            const roadGroup = new THREE.Group();
-            const roadBlockColor = mc_colors.road_grey; 
-            const roadWidthBlocks = Math.floor((GRID_WIDTH * 2.0) / CUBE_SIZE); // Adjusted multiplier for desired width
-            const roadDepthBlocks = Math.floor((GRID_DEPTH * 3.0) / CUBE_SIZE); // Adjusted multiplier for desired depth
-            const yPositionForRoadBlocks = -1; // One block level below the base of the contribution models.
-                                               // Top of these blocks will be at Y=0.
-
-            for (let i = -Math.floor(roadWidthBlocks / 2); i <= Math.floor(roadWidthBlocks / 2); i++) {
-                for (let j = -Math.floor(roadDepthBlocks / 2); j <= Math.floor(roadDepthBlocks / 2); j++) {
-                    // createBlock's y parameter is block layer index.
-                    // y=-1 means its center is at -0.5*CUBE_SIZE, so its top surface is at Y=0.
-                    const block = createBlock(roadBlockColor, i, yPositionForRoadBlocks, j);
-                    // Road blocks should not cast shadows themselves but should receive them.
-                    block.castShadow = false; 
-                    block.receiveShadow = true;
-                    roadGroup.add(block);
-                }
-            }
-            scene.add(roadGroup);
+            // --- Blocky Road Surface --- REMOVED
 
 
             // Renderer setup


### PR DESCRIPTION
This means I've removed all ground plane geometry from the scene. This includes:
- The recently implemented blocky road surface.
- Any previous flat PlaneGeometry ground surfaces.

Contribution models (Bare Ground, Starbucks, McDonald's, Lotte Tower) now appear directly against the sky blue scene background, resting at the Y=0 level. This simplifies the scene visually, as you requested. All model positioning and interaction logic remains consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the blocky road surface beneath the contribution models, resulting in a cleaner scene appearance. No other visible changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->