### PR TITLE
feat: Add ability to fetch and display GitHub contributions via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 When you first open `index.html`, it will display a 3D visualization based on a default sample set of contribution data (from `garden.js`). If you wish to visualize your own GitHub contributions, you can load your data using the method described below. This will replace the default view with your custom data.
 
-This project visualizes your contribution data in a 3D interactive display. The contribution data is loaded dynamically from a JSON file you provide.
+This project visualizes your contribution data in a 3D interactive display. It offers multiple ways to load contribution data.
 
-### How to Load Data to Replace the Default View
+### Loading Data from a JSON File
 
 1.  **Prepare your JSON file**: Create a JSON file containing your contribution data. The format is described below.
 2.  **Select the file**: On the webpage, click the "Choose File" (or similar, depending on your browser) button next to the "Load Contribution Data" button. Select your local JSON file.
@@ -36,3 +36,13 @@ Here is an example of a valid JSON file:
 ```
 
 Make sure your JSON file is correctly formatted before attempting to load it.
+
+### Fetching Data Directly from GitHub (for Public Contributions)
+
+You can also fetch a user's public GitHub contribution data directly:
+
+1.  **Enter Username:** In the input field labeled "Enter GitHub Username" (it defaults to "paypulse"), type the GitHub username whose public contribution data you wish to visualize.
+2.  **Click Fetch:** Click the "Fetch GitHub Data" button.
+3.  The application will then attempt to retrieve the contribution data for the specified user for the last year and update the graph. A loading message will appear while the data is being fetched.
+
+**Note:** This feature uses a third-party service (`https://github-contributions-api.jogruber.de/`) to fetch contribution data. This service provides public contribution data and its availability is not guaranteed. If you encounter issues, please ensure the username is correct and the service is operational.

--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
 <body>
     <input type="file" id="contributionFile" accept=".json">
     <button id="loadDataButton">Load Contribution Data</button>
+    <br>
+    <input type="text" id="githubUsername" placeholder="Enter GitHub Username" value="paypulse">
+    <button id="fetchGithubDataButton">Fetch GitHub Data</button>
+    <div id="loadingMessage" style="display:none; color: white; padding: 10px;">Loading GitHub data...</div>
     <div id="tooltip"></div>
     <div id="container"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
@@ -535,6 +539,80 @@
             };
 
             reader.readAsText(file);
+        });
+
+        document.getElementById('fetchGithubDataButton').addEventListener('click', () => {
+            const username = document.getElementById('githubUsername').value.trim();
+            if (!username) {
+                alert('Please enter a GitHub username.');
+                return;
+            }
+
+            const loadingMessageElement = document.getElementById('loadingMessage');
+            if (loadingMessageElement) {
+                loadingMessageElement.style.display = 'block';
+            }
+
+            const apiUrl = `https://github-contributions-api.jogruber.de/v4/${username}?y=last`; // Added ?y=last to fetch only last year data
+
+            fetch(apiUrl)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`API request failed with status ${response.status}: ${response.statusText}`);
+                    }
+                    return response.json(); // This returns a Promise
+                })
+                .then(data => {
+                    if (!data || !Array.isArray(data.contributions)) {
+                        console.error('Invalid data format received from API:', data);
+                        alert('Invalid data format received from API. Expected .contributions array.');
+                        return; // Stop processing
+                    }
+
+                    const transformedData = data.contributions.map(item => ({
+                        date: item.date,
+                        count: item.count
+                    }));
+
+                    currentContributions = transformedData; // Update the global variable
+                    
+                    // Clear existing cubes from the scene before regenerating
+                    if (window.contributionCubesGroup) {
+                        while (window.contributionCubesGroup.children.length > 0) {
+                            const modelGroup = window.contributionCubesGroup.children[0]; // This is a THREE.Group
+                            // Dispose of geometries and materials of meshes within this modelGroup
+                            modelGroup.children.forEach(mesh => {
+                                if (mesh.geometry) {
+                                    mesh.geometry.dispose();
+                                }
+                                if (mesh.material) {
+                                    if (Array.isArray(mesh.material)) {
+                                        mesh.material.forEach(m => m.dispose());
+                                    } else {
+                                        mesh.material.dispose();
+                                    }
+                                }
+                            });
+                            window.contributionCubesGroup.remove(modelGroup); // Remove the group itself
+                        }
+                    }
+
+                    if (typeof generateContributionGraph === 'function') {
+                        generateContributionGraph();
+                        alert('GitHub data loaded and graph updated!');
+                    } else {
+                        alert('Error: generateContributionGraph function not found, but data was processed.');
+                    }
+                })
+                .catch(error => {
+                    console.error('Error fetching or processing GitHub data:', error);
+                    alert('Failed to fetch or process GitHub data: ' + error.message);
+                })
+                .finally(() => {
+                    if (loadingMessageElement) {
+                        loadingMessageElement.style.display = 'none';
+                    }
+                });
         });
 
         init();


### PR DESCRIPTION
This commit introduces a new feature allowing you to visualize GitHub contribution data by fetching it directly for a specified username.

Key changes:
- Added UI elements (text input for username, fetch button) to index.html.
- Implemented JavaScript logic to call a third-party API proxy (https://github-contributions-api.jogruber.de/) to retrieve public contribution data for the last year.
- Added data processing to transform the API response into the format required by the 3D graph.
- Integrated graph clearing and regeneration to display the fetched data.
- Ensured the new feature complements existing data loading methods (default data and JSON file upload).
- Updated README.md with instructions for the new feature, including acknowledgment of the third-party API.

You can now directly input a GitHub username (defaults to "paypulse") to see your contribution history visualized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to fetch and display GitHub contribution data for any username using a new input field and button.
  - Users can now dynamically update the 3D contribution graph with data retrieved directly from GitHub via a third-party API.

- **Documentation**
  - Updated instructions in the README to reflect the new method for loading contribution data and clarified existing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->